### PR TITLE
Dont validate discriminator value for lenient discriminator

### DIFF
--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -136,9 +136,12 @@ function validateDiscriminator (report, schema, json) {
 
   // to conform to the Azure specs, we accept a lenient discriminator. if the type is missing in the
   // payload we use the base class. Also if the type doesn't match anything, we use the base class.
+  var basePolymorphicSchemaDiscriminatorType =
+    basePolymorphicSchema.__$refResolved.properties[discriminatorPropertyName].enum[0]
+
   var jsonDiscriminatorValue =
     json[discriminatorPropertyName] ||
-    basePolymorphicSchema.__$refResolved.properties[discriminatorPropertyName].enum[0]
+    basePolymorphicSchemaDiscriminatorType
 
   var schemaToValidate =
     schema.oneOf.find(
@@ -148,6 +151,10 @@ function validateDiscriminator (report, schema, json) {
         jsonDiscriminatorValue
     ) || basePolymorphicSchema
 
+  // if the schema to validate is the base schema, we dont need to validate the discriminator enum value.
+  if (schemaToValidate === basePolymorphicSchema) {
+    json[discriminatorPropertyName] = basePolymorphicSchemaDiscriminatorType
+  }
   ZSchemaValidator.validate.call(this, report, schemaToValidate, json)
   return true
 }


### PR DESCRIPTION
- when in the case of a lenient discriminator ( no discriminator value or no match ), don't validate
the enum value is it is not needed.