### PR TITLE
Add support for validating readonly properties in the request payload

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -113,6 +113,7 @@ function createJSONValidator () {
   ZSchemaValidator.JsonValidators.type = customValidators.typeValidator;
   ZSchemaValidator.JsonValidators.required = customValidators.requiredPropertyValidator;
   ZSchemaValidator.JsonValidators.oneOf = customValidators.oneOf;
+  ZSchemaValidator.JsonValidators.readOnly = customValidators.readOnlyValidator;
 
   var validator = new ZSchema({
     breakOnFirstError: false,

--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -205,8 +205,31 @@ function shouldSkipValidate (options, errors) {
     });
 }
 
+function readOnlyValidator (report, schema, json) {
+  var isResponse = this.validateOptions && this.validateOptions.isResponse;
+
+  if (!isResponse && schema && schema.readOnly && json) {
+    let errorMessage = 'ReadOnly property `"{0}": ';
+    
+    if (schema && schema.type === 'string') {
+      errorMessage += '"{1}"';
+    } else {
+      errorMessage += '{1}';
+    }
+    errorMessage += '`, cannot be sent in the request.';
+    report.addCustomError(
+      'READONLY_PROPERTY_NOT_ALLOWED_IN_REQUEST',
+      errorMessage,
+      [report.parentReport.path[0], json],
+      null,
+      schema
+    );
+  }
+}
+
 module.exports.shouldSkipValidate = shouldSkipValidate;
 module.exports.enumValidator = enumValidator;
 module.exports.requiredPropertyValidator = requiredPropertyValidator;
 module.exports.typeValidator = typeValidator;
 module.exports.oneOf = oneOf;
+module.exports.readOnlyValidator = readOnlyValidator;

--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -126,22 +126,22 @@ function oneOf (report, schema, json) {
 function validateDiscriminator (report, schema, json) {
   var basePolymorphicSchema = schema.oneOf.find(
     s => s.__$refResolved && s.__$refResolved.discriminator !== undefined
-  )
+  );
 
   // if none of the oneOf subschemas has a discriminator, we are not in a polymorphic oneOf.
   if (!basePolymorphicSchema) {
-    return false
+    return false;
   }
-  var discriminatorPropertyName = basePolymorphicSchema.__$refResolved.discriminator
+  var discriminatorPropertyName = basePolymorphicSchema.__$refResolved.discriminator;
 
   // to conform to the Azure specs, we accept a lenient discriminator. if the type is missing in the
   // payload we use the base class. Also if the type doesn't match anything, we use the base class.
   var basePolymorphicSchemaDiscriminatorValue =
-    basePolymorphicSchema.__$refResolved.properties[discriminatorPropertyName].enum[0]
+    basePolymorphicSchema.__$refResolved.properties[discriminatorPropertyName].enum[0];
 
-  var jsonDiscriminatorValue =
+    var jsonDiscriminatorValue =
     json[discriminatorPropertyName] ||
-    basePolymorphicSchemaDiscriminatorValue
+    basePolymorphicSchemaDiscriminatorValue;
 
   var schemaToValidate =
     schema.oneOf.find(
@@ -149,14 +149,22 @@ function validateDiscriminator (report, schema, json) {
         s.__$refResolved &&
         s.__$refResolved.properties[discriminatorPropertyName].enum[0] ===
         jsonDiscriminatorValue
-    ) || basePolymorphicSchema
+    ) || basePolymorphicSchema;
+  
+  var isJsonObject = typeof json === 'object' && json !== null && !Array.isArray(json);
 
-  // if the schema to validate is the base schema, we dont need to validate the discriminator enum value.
-  if (schemaToValidate === basePolymorphicSchema) {
-    json[discriminatorPropertyName] = basePolymorphicSchemaDiscriminatorValue
+  // if the schema to validate is the base schema and the payload is of type object and if the
+  // discriminator property is actually present in the payload then, we do not need to validate
+  // the discriminator enum value.
+  if (
+    schemaToValidate === basePolymorphicSchema &&
+    isJsonObject &&
+    json[discriminatorPropertyName] != undefined
+  ) {
+    json[discriminatorPropertyName] = basePolymorphicSchemaDiscriminatorValue;
   }
-  ZSchemaValidator.validate.call(this, report, schemaToValidate, json)
-  return true
+  ZSchemaValidator.validate.call(this, report, schemaToValidate, json);
+  return true;
 }
 
 function whatIs (what) {
@@ -190,11 +198,11 @@ function whatIs (what) {
 
 function shouldSkipValidate (options, errors) {
   return options &&
-      Array.isArray(options.includeErrors) &&
-      options.includeErrors.length > 0 &&
-      !errors.some(function (err) {
-        return options.includeErrors.includes(err);
-      });
+    Array.isArray(options.includeErrors) &&
+    options.includeErrors.length > 0 &&
+    !errors.some(function (err) {
+      return options.includeErrors.includes(err);
+    });
 }
 
 module.exports.shouldSkipValidate = shouldSkipValidate;

--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -207,6 +207,7 @@ function readOnlyValidator (report, schema, json) {
   }
 
   var isResponse = this.validateOptions && this.validateOptions.isResponse;
+  
   if (!isResponse && schema && schema.readOnly && json !== undefined) {
     let errorMessage = 'ReadOnly property `"{0}": ';
     

--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -153,14 +153,9 @@ function validateDiscriminator (report, schema, json) {
   
   var isJsonObject = typeof json === 'object' && json !== null && !Array.isArray(json);
 
-  // if the schema to validate is the base schema and the payload is of type object and if the
-  // discriminator property is actually present in the payload then, we do not need to validate
-  // the discriminator enum value.
-  if (
-    schemaToValidate === basePolymorphicSchema &&
-    isJsonObject &&
-    json[discriminatorPropertyName] != undefined
-  ) {
+  // if the schema to validate is the base schema and the payload is of type object then,
+  // we do not need to validate the discriminator enum value.
+  if (schemaToValidate === basePolymorphicSchema && isJsonObject) {
     json[discriminatorPropertyName] = basePolymorphicSchemaDiscriminatorValue;
   }
   ZSchemaValidator.validate.call(this, report, schemaToValidate, json);
@@ -206,12 +201,16 @@ function shouldSkipValidate (options, errors) {
 }
 
 function readOnlyValidator (report, schema, json) {
-  var isResponse = this.validateOptions && this.validateOptions.isResponse;
+  // http://json-schema.org/latest/json-schema-validation.html#rfc.section.10.3
+  if (shouldSkipValidate(this.validateOptions, ['READONLY_PROPERTY_NOT_ALLOWED_IN_REQUEST'])) {
+    return;
+  }
 
-  if (!isResponse && schema && schema.readOnly && json) {
+  var isResponse = this.validateOptions && this.validateOptions.isResponse;
+  if (!isResponse && schema && schema.readOnly && json !== undefined) {
     let errorMessage = 'ReadOnly property `"{0}": ';
     
-    if (schema && schema.type === 'string') {
+    if (schema && schema.type === 'string' && typeof json === 'string') {
       errorMessage += '"{1}"';
     } else {
       errorMessage += '{1}';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yasway",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "A library that simplifies Swagger integrations.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Definition of `readOnly` and `discriminator` in Open API Spec 2.0 can be found [here](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields-13).

https://github.com/Azure/oav/pull/424