### PR TITLE
Returning schema paths for missing required property

### DIFF
--- a/lib/types/parameter-value.js
+++ b/lib/types/parameter-value.js
@@ -26,7 +26,6 @@
 
 var _ = require('lodash');
 var helpers = require('../helpers');
-var JsonRefs = require('json-refs');
 
 /**
  * Object representing a parameter value.
@@ -50,7 +49,6 @@ var JsonRefs = require('json-refs');
  * @constructor
  */
 function ParameterValue (parameterObject, raw, validateOptions) {
-  var pPath = JsonRefs.pathFromPtr(parameterObject.ptr);
   var processed = false;
   var schema = parameterObject.schema;
   var error;
@@ -146,7 +144,7 @@ function ParameterValue (parameterObject, raw, validateOptions) {
               }
             } catch (err) {
               err.failedValidation = true;
-              err.path = pPath;
+              err.schemaPath = parameterObject.ptr;
 
               error = err;
               isValid = false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yasway",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "A library that simplifies Swagger integrations.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/test-parameter.js
+++ b/test/test-parameter.js
@@ -1527,16 +1527,16 @@ describe('Parameter', function () {
         assert.ok(_.isUndefined(paramValue.error));
       });
 
-      it.skip('missing required value (without default)', function () {
-        var paramValue = swaggerApi.getOperation('/pet/findByTags', 'get').getParameter('tags').getValue({
-          query: {}
-        });
+      it('missing required value', function () {
+        var paramValue = swaggerApi.getOperation('/pet', 'post').getParameter('body').getValue({});
         var error = paramValue.error;
 
         assert.ok(_.isUndefined(paramValue.value));
+        assert.ok(_.isUndefined(error.path));
         assert.ok(paramValue.valid === false);
         assert.equal(error.message, 'Value is required but was not provided');
-        assert.equal(error.code, 'REQUIRED');
+        assert.equal(error.code, 'MISSING_REQUIRED_PARAMETER');
+        assert.equal(error.schemaPath, '#/paths/~1pet/post/parameters/0');
         assert.ok(error.failedValidation);
       });
 


### PR DESCRIPTION
Change to not return missing required property path as "path" but instead as "schemaPath", and to not try and convert this path into a JSON ref.