### PR TITLE
Skip to load parameter value when it's not provided.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -206,14 +206,9 @@ var convertValue = module.exports.convertValue = function (schema, options, valu
     return value;
   }
 
-  // If there is no value, do not convert it
-  if (_.isUndefined(value)) {
+  // If there is no value or value is null, do not convert it
+  if (_.isUndefined(value) || value === null) {
     return value;
-  }
-
-  // If the value is null, do not convert it
-  if (!value) {
-    return undefined;
   }
 
   // Convert Buffer value to String

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -211,6 +211,11 @@ var convertValue = module.exports.convertValue = function (schema, options, valu
     return value;
   }
 
+  // If the value is null, do not convert it
+  if (!value) {
+    return undefined;
+  }
+
   // Convert Buffer value to String
   // (We use this type of check to identify Buffer objects.  The browser does not have a Buffer type and to avoid having
   //  import the browserify buffer module, we just do a simple check.  This is brittle but should work.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yasway",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "A library that simplifies Swagger integrations.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Fixed the internal error about ''Cannot read property 'readUInt8' of null".