### PR TITLE
  Add path info to error message for parameters validation in examples.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 ## Release Notes
 
+### v1.8.4
+* Set path info in `invalid_request_parameter` error message when the internal error message doesn't have path info.
+
 ### TBD
 
 * Added support for registering custom format validators via `options.customFormats` when creating the `SwaggerApi`

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -277,7 +277,7 @@ Operation.prototype.validateRequest = function (req, options) {
                                                                'Value failed JSON Schema validation' :
                                                                paramValue.error.message),
         name: paramValue.parameterObject.name,
-        path: (paramValue.error.path || []).length > 1 ? paramValue.error.path : ["parameters", param.name],
+        path: (paramValue.error.path || []).length > 1 ? paramValue.error.path : ['parameters', param.name],
         schemaPath: paramValue.error.schemaPath || ''
       };
 

--- a/lib/types/operation.js
+++ b/lib/types/operation.js
@@ -277,7 +277,7 @@ Operation.prototype.validateRequest = function (req, options) {
                                                                'Value failed JSON Schema validation' :
                                                                paramValue.error.message),
         name: paramValue.parameterObject.name,
-        path: paramValue.error.path,
+        path: (paramValue.error.path || []).length > 1 ? paramValue.error.path : ["parameters", param.name],
         schemaPath: paramValue.error.schemaPath || ''
       };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yasway",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "A library that simplifies Swagger integrations.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/test-operation.js
+++ b/test/test-operation.js
@@ -438,7 +438,7 @@ describe('Operation', function () {
               in: 'path',
               message: 'Invalid parameter (petId): Expected type integer but found type string',
               name: 'petId',
-              path: [],
+              path: ['parameters', 'petId'],
               schemaPath: ''
             }
           ]);
@@ -894,7 +894,7 @@ describe('Operation', function () {
               in: 'path',
               message: 'Invalid parameter (petId): Expected type integer but found type string',
               name: 'petId',
-              path: [],
+              path: ['parameters', 'petId'],
               schemaPath: ''
             }
           ]);


### PR DESCRIPTION
Set path info in error message in case of it's null in internal error
messages.