### PR TITLE
[S1007882] Support x-ms-mutability in response validation

### DIFF
--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -79,6 +79,31 @@ function requiredPropertyValidator (report, schema, json) {
   }
 }
 
+function writeOnlyValidator(report, schema, json) {
+  if (shouldSkipValidate(this.validateOptions, ['WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE'])) {
+    return
+  }
+
+  var isResponse = this.validateOptions && this.validateOptions.isResponse
+  var idx = schema.definitions.length;
+  var definitionPropertyName;
+  var xMsMutability;
+
+  while (idx --) {
+    definitionPropertyName = schema.definitions[idx];
+    xMsMutability = (schema.definitions && schema.definitions[`${definitionPropertyName}`]) && schema.definitions[`${definitionPropertyName}`]['x-ms-mutability'];
+    if (isResponse && xMsMutability.indexOf('read') === -1) {
+      report.addError(
+        'WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE',
+        [definitionPropertyName],
+        null,
+        schema
+      );
+    }
+  }
+
+}
+
 function typeValidator (report, schema, json) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.2.2
   if (schema.type !== 'null' && shouldSkipValidate(this.validateOptions, ['INVALID_TYPE'])) {
@@ -290,6 +315,8 @@ function customValidatorFn (report, schema, json) {
 }
 
 
+
+
 module.exports.shouldSkipValidate = shouldSkipValidate;
 module.exports.enumValidator = enumValidator;
 module.exports.requiredPropertyValidator = requiredPropertyValidator;
@@ -297,3 +324,4 @@ module.exports.typeValidator = typeValidator;
 module.exports.oneOf = oneOf;
 module.exports.readOnlyValidator = readOnlyValidator;
 module.exports.customValidator = customValidatorFn;
+module.exports.writeOnlyValidator = writeOnlyValidator;

--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -209,7 +209,14 @@ function isPropertyWriteOnly (xMsMutability) {
   return xMsMutability && xMsMutability.indexOf('read') === -1 && (xMsMutability.indexOf('create') != -1 || xMsMutability.indexOf('update') != -1);
 }
 
-function checkSecretPropertyInResponse (isResponse, schema, xMsSecret, json, report) {
+function checkSecretPropertyInResponse (validateOptions, schema, json, report) {
+  if (shouldSkipValidate(validateOptions, ['SECRET_PROPERTY'])) {
+    return
+  }
+
+  var isResponse = validateOptions && validateOptions.isResponse
+  var xMsSecret = schema && schema['x-ms-secret']
+
   if (isResponse && schema && xMsSecret && json !== undefined) {
     let errorMessage = 'Secret property `"{0}": ';
 
@@ -236,9 +243,17 @@ function checkSecretPropertyInResponse (isResponse, schema, xMsSecret, json, rep
   }
 }
 
-function checkWriteOnlyPropertyInResponse (isResponse, schema, xMsMutability, json, report) {
+function checkWriteOnlyPropertyInResponse (validateOptions, schema, json, report) {
   // Check if there's a write-only property in the response. 
   // Write-only property definition: Property with 'x-ms-mutability' that does NOT have ['read'] and only has 'create' or 'update' or both
+  
+  if (shouldSkipValidate(validateOptions, ['WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE'])) {
+    return
+  }
+
+  var isResponse = validateOptions && validateOptions.isResponse
+  var xMsMutability = schema && schema['x-ms-mutability']
+
   if (isResponse && schema && isPropertyWriteOnly(xMsMutability) && json !== undefined) {
     let errorMessage = 'Write-only property `"{0}": ';
 
@@ -308,16 +323,8 @@ function readOnlyValidator (report, schema, json) {
 }
 
 function customValidatorFn (report, schema, json) {
-  if (shouldSkipValidate(this.validateOptions, ['SECRET_PROPERTY','WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE'])) {
-    return
-  }
-
-  var isResponse = this.validateOptions && this.validateOptions.isResponse
-  var xMsSecret = schema && schema['x-ms-secret']
-  var xMsMutability = schema && schema['x-ms-mutability']
-
-  checkWriteOnlyPropertyInResponse(isResponse, schema, xMsMutability, json, report);
-  checkSecretPropertyInResponse(isResponse, schema, xMsSecret, json, report);
+  checkWriteOnlyPropertyInResponse(this.validateOptions, schema, json, report);
+  checkSecretPropertyInResponse(this.validateOptions, schema, json, report);
 }
 
 

--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -212,11 +212,10 @@ function isPropertyWriteOnly (xMsMutability) {
 function checkSecretPropertyInResponse (isResponse, schema, xMsSecret, json, report) {
   if (isResponse && schema && xMsSecret && json !== undefined) {
     let errorMessage = 'Secret property `"{0}": ';
-    
+
     if (schema && schema.type === 'string' && typeof json === 'string') {
       errorMessage += '"{1}"';
-    }
-    else {
+    } else {
       errorMessage += '{1}';
     }
     let propertyName = '';
@@ -224,11 +223,11 @@ function checkSecretPropertyInResponse (isResponse, schema, xMsSecret, json, rep
     if (schema.title && typeof schema.title === 'string') {
       try {
         let result = JSON.parse(schema.title);
+
         if (Array.isArray(result.path) && result.path.length) {
           propertyName = result.path[result.path.length - 1];
         }
-      }
-      catch (err) {
+      } catch (err) {
         // do nothing
       }
     }
@@ -245,8 +244,7 @@ function checkWriteOnlyPropertyInResponse (isResponse, schema, xMsMutability, js
 
     if (schema && schema.type === 'string' && typeof json === 'string') {
       errorMessage += '"{1}"';
-    }
-    else {
+    } else {
       errorMessage += '{1}';
     }
     let propertyName = '';
@@ -254,11 +252,11 @@ function checkWriteOnlyPropertyInResponse (isResponse, schema, xMsMutability, js
     if (schema.title && typeof schema.title === 'string') {
       try {
         let result = JSON.parse(schema.title);
+
         if (Array.isArray(result.path) && result.path.length) {
           propertyName = result.path[result.path.length - 1];
         }
-      }
-      catch (err) {
+      } catch (err) {
         // do nothing
       }
     }

--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -312,6 +312,7 @@ function customValidatorFn (report, schema, json) {
 
   var isResponse = this.validateOptions && this.validateOptions.isResponse
   var xMsSecret = schema && schema['x-ms-secret']
+  var xMsMutability = schema && schema['x-ms-mutability']
 
   checkWriteOnlyPropertyInResponse(isResponse, schema, xMsMutability, json, report);
   checkSecretPropertyInResponse(isResponse, schema, xMsSecret, json, report);

--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -3,7 +3,7 @@
 var Report = require('@ts-common/z-schema/src/Report');
 var ZSchemaValidator = require('@ts-common/z-schema/src/JsonValidation');
 
-function enumValidator (report, schema, json) {
+function enumValidator(report, schema, json) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.1.2
   if (shouldSkipValidate(this.validateOptions, ['ENUM_CASE_MISMATCH', 'ENUM_MISMATCH'])) {
     return;
@@ -40,7 +40,7 @@ function enumValidator (report, schema, json) {
   }
 }
 
-function requiredPropertyValidator (report, schema, json) {
+function requiredPropertyValidator(report, schema, json) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.3.2
   if (shouldSkipValidate(this.validateOptions, ['OBJECT_MISSING_REQUIRED_PROPERTY'])) {
     return;
@@ -63,7 +63,7 @@ function requiredPropertyValidator (report, schema, json) {
       this.validateOptions &&
       this.validateOptions.isResponse &&
       (xMsMutability &&
-        xMsMutability.indexOf('read') === -1) 
+        xMsMutability.indexOf('read') === -1)
     ) {
       schema.properties[`${requiredPropertyName}`].isRequired = true;
       continue;
@@ -79,32 +79,7 @@ function requiredPropertyValidator (report, schema, json) {
   }
 }
 
-function writeOnlyValidator(report, schema, json) {
-  if (shouldSkipValidate(this.validateOptions, ['WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE'])) {
-    return
-  }
-
-  var isResponse = this.validateOptions && this.validateOptions.isResponse
-  var idx = schema.definitions.length;
-  var definitionPropertyName;
-  var xMsMutability;
-
-  while (idx --) {
-    definitionPropertyName = schema.definitions[idx];
-    xMsMutability = (schema.definitions && schema.definitions[`${definitionPropertyName}`]) && schema.definitions[`${definitionPropertyName}`]['x-ms-mutability'];
-    if (isResponse && xMsMutability.indexOf('read') === -1) {
-      report.addError(
-        'WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE',
-        [definitionPropertyName],
-        null,
-        schema
-      );
-    }
-  }
-
-}
-
-function typeValidator (report, schema, json) {
+function typeValidator(report, schema, json) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.2.2
   if (schema.type !== 'null' && shouldSkipValidate(this.validateOptions, ['INVALID_TYPE'])) {
     return;
@@ -127,7 +102,7 @@ function typeValidator (report, schema, json) {
   }
 }
 
-function oneOf (report, schema, json) {
+function oneOf(report, schema, json) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.5.2
   var passes = 0,
     subReports = [],
@@ -140,7 +115,7 @@ function oneOf (report, schema, json) {
   }
 
   while (idx--) {
-    subReport = new Report(report, {maxErrors: 1})
+    subReport = new Report(report, { maxErrors: 1 })
     subReports.push(subReport)
     if (ZSchemaValidator.validate.call(this, subReport, schema.oneOf[idx], json) === true) {
       passes++
@@ -153,7 +128,7 @@ function oneOf (report, schema, json) {
   }
 }
 
-function validateDiscriminator (report, schema, json) {
+function validateDiscriminator(report, schema, json) {
   var basePolymorphicSchema = schema.oneOf.find(
     s => s.__$refResolved && s.__$refResolved.discriminator !== undefined
   );
@@ -169,7 +144,7 @@ function validateDiscriminator (report, schema, json) {
   var basePolymorphicSchemaDiscriminatorValue =
     basePolymorphicSchema.__$refResolved.properties[discriminatorPropertyName].enum[0];
 
-    var jsonDiscriminatorValue =
+  var jsonDiscriminatorValue =
     json[discriminatorPropertyName] ||
     basePolymorphicSchemaDiscriminatorValue;
 
@@ -180,7 +155,7 @@ function validateDiscriminator (report, schema, json) {
         s.__$refResolved.properties[discriminatorPropertyName].enum[0] ===
         jsonDiscriminatorValue
     ) || basePolymorphicSchema;
-  
+
   var isJsonObject = typeof json === 'object' && json !== null && !Array.isArray(json);
 
   // if the schema to validate is the base schema and the payload is of type object then,
@@ -192,7 +167,7 @@ function validateDiscriminator (report, schema, json) {
   return true;
 }
 
-function whatIs (what) {
+function whatIs(what) {
   var to = typeof what;
 
   if (to === 'object') {
@@ -221,7 +196,7 @@ function whatIs (what) {
   return to; // undefined, boolean, string, function
 }
 
-function shouldSkipValidate (options, errors) {
+function shouldSkipValidate(options, errors) {
   return options &&
     Array.isArray(options.includeErrors) &&
     options.includeErrors.length > 0 &&
@@ -230,17 +205,76 @@ function shouldSkipValidate (options, errors) {
     });
 }
 
-function readOnlyValidator (report, schema, json) {
+function isPropertyWriteOnly(xMsMutability) {
+  return xMsMutability && xMsMutability.indexOf('read') === -1 && xMsMutability.indexOf('create') != -1 && xMsMutability.indexOf('update') != -1;
+}
+
+function checkSecretPropertyInResponse(isResponse, schema, xMsSecret, json, report) {
+  if (isResponse && schema && xMsSecret && json !== undefined) {
+    let errorMessage = 'Secret property `"{0}": ';
+    if (schema && schema.type === 'string' && typeof json === 'string') {
+      errorMessage += '"{1}"';
+    }
+    else {
+      errorMessage += '{1}';
+    }
+    let propertyName = '';
+    if (schema.title && typeof schema.title === 'string') {
+      try {
+        let result = JSON.parse(schema.title);
+        if (Array.isArray(result.path) && result.path.length) {
+          propertyName = result.path[result.path.length - 1];
+        }
+      }
+      catch (err) {
+        // do nothing
+      }
+    }
+    errorMessage += '`, cannot be sent in the response.';
+    report.addCustomError('SECRET_PROPERTY', errorMessage, [propertyName, json], null, schema);
+  }
+}
+
+function checkWriteOnlyPropertyInResponse(isResponse, schema, xMsMutability, json, report) {
+  // Check if there's a write-only property in the response. 
+  // To be more specific, we are checking if a property marked with 'x-ms-mutability' in the spec only has ['create','update'] and does NOT have ['read']
+  if (isResponse && schema && isPropertyWriteOnly(xMsMutability) && json !== undefined) {
+    let errorMessage = 'Write-only property `"{0}": ';
+    if (schema && schema.type === 'string' && typeof json === 'string') {
+      errorMessage += '"{1}"';
+    }
+    else {
+      errorMessage += '{1}';
+    }
+    let propertyName = '';
+    if (schema.title && typeof schema.title === 'string') {
+      try {
+        let result = JSON.parse(schema.title);
+        if (Array.isArray(result.path) && result.path.length) {
+          propertyName = result.path[result.path.length - 1];
+        }
+      }
+      catch (err) {
+        // do nothing
+      }
+    }
+    errorMessage += '`, is not allowed in the response.';
+    report.addCustomError('WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE', errorMessage, [propertyName, json], null, schema);
+  }
+}
+
+
+function readOnlyValidator(report, schema, json) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.10.3
   if (shouldSkipValidate(this.validateOptions, ['READONLY_PROPERTY_NOT_ALLOWED_IN_REQUEST'])) {
     return;
   }
 
   var isResponse = this.validateOptions && this.validateOptions.isResponse;
-  
+
   if (!isResponse && schema && schema.readOnly && json !== undefined) {
     let errorMessage = 'ReadOnly property `"{0}": ';
-    
+
     if (schema && schema.type === 'string' && typeof json === 'string') {
       errorMessage += '"{1}"';
     } else {
@@ -272,49 +306,18 @@ function readOnlyValidator (report, schema, json) {
   }
 }
 
-function customValidatorFn (report, schema, json) {
-  if (shouldSkipValidate(this.validateOptions, ['SECRET_PROPERTY'])) {
+function customValidatorFn(report, schema, json) {
+  if (shouldSkipValidate(this.validateOptions, ['SECRET_PROPERTY', 'WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE'])) {
     return
   }
 
   var isResponse = this.validateOptions && this.validateOptions.isResponse
   var xMsSecret = schema && schema['x-ms-secret']
+  var xMsMutability = schema && schema['x-ms-mutability']
 
-  if (isResponse && schema && xMsSecret && json !== undefined) {
-    let errorMessage = 'Secret property `"{0}": '
-
-    if (schema && schema.type === 'string' && typeof json === 'string') {
-      errorMessage += '"{1}"'
-    } else {
-      errorMessage += '{1}'
-    }
-
-    let propertyName = ''
-
-    if (schema.title && typeof schema.title === 'string') {
-      try {
-        let result = JSON.parse(schema.title)
-
-        if (Array.isArray(result.path) && result.path.length) {
-          propertyName = result.path[result.path.length - 1]
-        }
-      } catch (err) {
-        // do nothing
-      }
-    }
-
-    errorMessage += '`, cannot be sent in the response.'
-    report.addCustomError(
-      'SECRET_PROPERTY',
-      errorMessage,
-      [propertyName, json],
-      null,
-      schema
-    )
-  }
+  checkWriteOnlyPropertyInResponse(isResponse, schema, xMsMutability, json, report);
+  checkSecretPropertyInResponse(isResponse, schema, xMsSecret, json, report);
 }
-
-
 
 
 module.exports.shouldSkipValidate = shouldSkipValidate;
@@ -324,4 +327,3 @@ module.exports.typeValidator = typeValidator;
 module.exports.oneOf = oneOf;
 module.exports.readOnlyValidator = readOnlyValidator;
 module.exports.customValidator = customValidatorFn;
-module.exports.writeOnlyValidator = writeOnlyValidator;

--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -205,13 +205,14 @@ function shouldSkipValidate (options, errors) {
     });
 }
 
-function isPropertyWriteOnly(xMsMutability) {
+function isPropertyWriteOnly (xMsMutability) {
   return xMsMutability && xMsMutability.indexOf('read') === -1 && xMsMutability.indexOf('create') != -1 && xMsMutability.indexOf('update') != -1;
 }
 
-function checkSecretPropertyInResponse(isResponse, schema, xMsSecret, json, report) {
+function checkSecretPropertyInResponse (isResponse, schema, xMsSecret, json, report) {
   if (isResponse && schema && xMsSecret && json !== undefined) {
     let errorMessage = 'Secret property `"{0}": ';
+    
     if (schema && schema.type === 'string' && typeof json === 'string') {
       errorMessage += '"{1}"';
     }
@@ -219,6 +220,7 @@ function checkSecretPropertyInResponse(isResponse, schema, xMsSecret, json, repo
       errorMessage += '{1}';
     }
     let propertyName = '';
+
     if (schema.title && typeof schema.title === 'string') {
       try {
         let result = JSON.parse(schema.title);
@@ -235,11 +237,12 @@ function checkSecretPropertyInResponse(isResponse, schema, xMsSecret, json, repo
   }
 }
 
-function checkWriteOnlyPropertyInResponse(isResponse, schema, xMsMutability, json, report) {
+function checkWriteOnlyPropertyInResponse (isResponse, schema, xMsMutability, json, report) {
   // Check if there's a write-only property in the response. 
   // To be more specific, we are checking if a property marked with 'x-ms-mutability' in the spec only has ['create','update'] and does NOT have ['read']
   if (isResponse && schema && isPropertyWriteOnly(xMsMutability) && json !== undefined) {
     let errorMessage = 'Write-only property `"{0}": ';
+
     if (schema && schema.type === 'string' && typeof json === 'string') {
       errorMessage += '"{1}"';
     }
@@ -247,6 +250,7 @@ function checkWriteOnlyPropertyInResponse(isResponse, schema, xMsMutability, jso
       errorMessage += '{1}';
     }
     let propertyName = '';
+
     if (schema.title && typeof schema.title === 'string') {
       try {
         let result = JSON.parse(schema.title);

--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -206,7 +206,7 @@ function shouldSkipValidate (options, errors) {
 }
 
 function isPropertyWriteOnly (xMsMutability) {
-  return xMsMutability && xMsMutability.indexOf('read') === -1 && xMsMutability.indexOf('create') != -1 && xMsMutability.indexOf('update') != -1;
+  return xMsMutability && xMsMutability.indexOf('read') === -1 && (xMsMutability.indexOf('create') != -1 || xMsMutability.indexOf('update') != -1);
 }
 
 function checkSecretPropertyInResponse (isResponse, schema, xMsSecret, json, report) {
@@ -238,7 +238,7 @@ function checkSecretPropertyInResponse (isResponse, schema, xMsSecret, json, rep
 
 function checkWriteOnlyPropertyInResponse (isResponse, schema, xMsMutability, json, report) {
   // Check if there's a write-only property in the response. 
-  // To be more specific, we are checking if a property marked with 'x-ms-mutability' in the spec only has ['create','update'] and does NOT have ['read']
+  // Write-only property definition: Property with 'x-ms-mutability' that does NOT have ['read'] and only has 'create' or 'update' or both
   if (isResponse && schema && isPropertyWriteOnly(xMsMutability) && json !== undefined) {
     let errorMessage = 'Write-only property `"{0}": ';
 
@@ -308,7 +308,7 @@ function readOnlyValidator (report, schema, json) {
 }
 
 function customValidatorFn (report, schema, json) {
-  if (shouldSkipValidate(this.validateOptions, ['SECRET_PROPERTY'])) {
+  if (shouldSkipValidate(this.validateOptions, ['SECRET_PROPERTY','WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE'])) {
     return
   }
 

--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -3,7 +3,7 @@
 var Report = require('@ts-common/z-schema/src/Report');
 var ZSchemaValidator = require('@ts-common/z-schema/src/JsonValidation');
 
-function enumValidator(report, schema, json) {
+function enumValidator (report, schema, json) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.1.2
   if (shouldSkipValidate(this.validateOptions, ['ENUM_CASE_MISMATCH', 'ENUM_MISMATCH'])) {
     return;
@@ -40,7 +40,7 @@ function enumValidator(report, schema, json) {
   }
 }
 
-function requiredPropertyValidator(report, schema, json) {
+function requiredPropertyValidator (report, schema, json) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.4.3.2
   if (shouldSkipValidate(this.validateOptions, ['OBJECT_MISSING_REQUIRED_PROPERTY'])) {
     return;
@@ -63,7 +63,7 @@ function requiredPropertyValidator(report, schema, json) {
       this.validateOptions &&
       this.validateOptions.isResponse &&
       (xMsMutability &&
-        xMsMutability.indexOf('read') === -1)
+        xMsMutability.indexOf('read') === -1) 
     ) {
       schema.properties[`${requiredPropertyName}`].isRequired = true;
       continue;
@@ -79,7 +79,7 @@ function requiredPropertyValidator(report, schema, json) {
   }
 }
 
-function typeValidator(report, schema, json) {
+function typeValidator (report, schema, json) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.2.2
   if (schema.type !== 'null' && shouldSkipValidate(this.validateOptions, ['INVALID_TYPE'])) {
     return;
@@ -102,7 +102,7 @@ function typeValidator(report, schema, json) {
   }
 }
 
-function oneOf(report, schema, json) {
+function oneOf (report, schema, json) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.5.5.2
   var passes = 0,
     subReports = [],
@@ -115,7 +115,7 @@ function oneOf(report, schema, json) {
   }
 
   while (idx--) {
-    subReport = new Report(report, { maxErrors: 1 })
+    subReport = new Report(report, {maxErrors: 1})
     subReports.push(subReport)
     if (ZSchemaValidator.validate.call(this, subReport, schema.oneOf[idx], json) === true) {
       passes++
@@ -128,7 +128,7 @@ function oneOf(report, schema, json) {
   }
 }
 
-function validateDiscriminator(report, schema, json) {
+function validateDiscriminator (report, schema, json) {
   var basePolymorphicSchema = schema.oneOf.find(
     s => s.__$refResolved && s.__$refResolved.discriminator !== undefined
   );
@@ -144,7 +144,7 @@ function validateDiscriminator(report, schema, json) {
   var basePolymorphicSchemaDiscriminatorValue =
     basePolymorphicSchema.__$refResolved.properties[discriminatorPropertyName].enum[0];
 
-  var jsonDiscriminatorValue =
+    var jsonDiscriminatorValue =
     json[discriminatorPropertyName] ||
     basePolymorphicSchemaDiscriminatorValue;
 
@@ -155,7 +155,7 @@ function validateDiscriminator(report, schema, json) {
         s.__$refResolved.properties[discriminatorPropertyName].enum[0] ===
         jsonDiscriminatorValue
     ) || basePolymorphicSchema;
-
+  
   var isJsonObject = typeof json === 'object' && json !== null && !Array.isArray(json);
 
   // if the schema to validate is the base schema and the payload is of type object then,
@@ -167,7 +167,7 @@ function validateDiscriminator(report, schema, json) {
   return true;
 }
 
-function whatIs(what) {
+function whatIs (what) {
   var to = typeof what;
 
   if (to === 'object') {
@@ -196,7 +196,7 @@ function whatIs(what) {
   return to; // undefined, boolean, string, function
 }
 
-function shouldSkipValidate(options, errors) {
+function shouldSkipValidate (options, errors) {
   return options &&
     Array.isArray(options.includeErrors) &&
     options.includeErrors.length > 0 &&
@@ -263,18 +263,17 @@ function checkWriteOnlyPropertyInResponse(isResponse, schema, xMsMutability, jso
   }
 }
 
-
-function readOnlyValidator(report, schema, json) {
+function readOnlyValidator (report, schema, json) {
   // http://json-schema.org/latest/json-schema-validation.html#rfc.section.10.3
   if (shouldSkipValidate(this.validateOptions, ['READONLY_PROPERTY_NOT_ALLOWED_IN_REQUEST'])) {
     return;
   }
 
   var isResponse = this.validateOptions && this.validateOptions.isResponse;
-
+  
   if (!isResponse && schema && schema.readOnly && json !== undefined) {
     let errorMessage = 'ReadOnly property `"{0}": ';
-
+    
     if (schema && schema.type === 'string' && typeof json === 'string') {
       errorMessage += '"{1}"';
     } else {
@@ -306,14 +305,13 @@ function readOnlyValidator(report, schema, json) {
   }
 }
 
-function customValidatorFn(report, schema, json) {
-  if (shouldSkipValidate(this.validateOptions, ['SECRET_PROPERTY', 'WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE'])) {
+function customValidatorFn (report, schema, json) {
+  if (shouldSkipValidate(this.validateOptions, ['SECRET_PROPERTY'])) {
     return
   }
 
   var isResponse = this.validateOptions && this.validateOptions.isResponse
   var xMsSecret = schema && schema['x-ms-secret']
-  var xMsMutability = schema && schema['x-ms-mutability']
 
   checkWriteOnlyPropertyInResponse(isResponse, schema, xMsMutability, json, report);
   checkSecretPropertyInResponse(isResponse, schema, xMsSecret, json, report);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yasway",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "A library that simplifies Swagger integrations.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/browser/documents/2.0/swagger.yaml
+++ b/test/browser/documents/2.0/swagger.yaml
@@ -680,6 +680,18 @@ definitions:
         - "available"
         - "pending"
         - "sold"
+      secret:
+        type: "string"
+        x-ms-secret: ["secret"]
+      writeOnly:
+        type: "string"
+        x-ms-mutability: ["create", "update"]
+      createOnly:
+        type: "string"
+        x-ms-mutability: ["create"]
+      updateOnly:
+        type: "string"
+        x-ms-mutability: ["update"]
     type: "object"
     xml:
       name: "Pet"

--- a/test/test-response.js
+++ b/test/test-response.js
@@ -129,6 +129,30 @@ describe('Response', function () {
       photoUrls: []
     };
 
+    var writeOnlyPet = {
+      name: 'Test Pet',
+      photoUrls: [],
+      writeOnly: 'writeonly'
+    };
+
+    var createOnlyPet = {
+      name: 'Test Pet',
+      photoUrls: [],
+      createOnly: 'createonly'
+    }
+
+    var updateOnlyPet = {
+      name: 'Test Pet',
+      photoUrls: [],
+      updateOnly: 'updateonly'
+    }
+
+    var secretPet = {
+      name: 'Test Pet',
+      photoUrls: [],
+      secret: 'password'
+    }
+
     describe('validate Content-Type', function () {
       describe('operation level produces', function () {
         var cSway;
@@ -617,6 +641,150 @@ describe('Response', function () {
                     }
                   ],
                   message: 'Invalid body: String is too short (2 chars), minimum 3',
+                  path: []
+                }
+              ]);
+              assert.equal(results.warnings.length, 0);
+            })
+            .then(done, done);
+        });
+
+        it('Test if response has secret property marked with x-ms-secret', function (done) {
+          var cSwaggerDoc = _.cloneDeep(helpers.swaggerDoc);
+
+          Sway.create({
+            definition: cSwaggerDoc
+          })
+            .then(function (api) {
+              var results = api.getOperation('/pet/{petId}', 'get').validateResponse({
+                body: secretPet,
+                encoding: 'utf-8',
+                headers: {
+                  'content-type': 'application/json'
+                },
+                statusCode: 200
+              });
+
+              assert.deepEqual(results.errors, [
+                {
+                  code: 'INVALID_RESPONSE_BODY',
+                  errors: [
+                    {
+                      code: 'SECRET_PROPERTY',
+                      message: 'Secret property `"": "password"`, cannot be sent in the response.',
+                      params: ["", "password"],
+                      path: ["secret"]
+                    }
+                  ],
+                  message: 'Invalid body: Secret property `"": "password"`, cannot be sent in the response.',
+                  path: []
+                }
+              ]);
+              assert.equal(results.warnings.length, 0);
+            })
+            .then(done, done);
+        });
+
+        it('Test if response has WRITE only property marked with x-ms-mutability', function (done) {
+          var cSwaggerDoc = _.cloneDeep(helpers.swaggerDoc);
+
+          Sway.create({
+            definition: cSwaggerDoc
+          })
+            .then(function (api) {
+              var results = api.getOperation('/pet/{petId}', 'get').validateResponse({
+                body: writeOnlyPet,
+                encoding: 'utf-8',
+                headers: {
+                  'content-type': 'application/json'
+                },
+                statusCode: 200
+              });
+
+              assert.deepEqual(results.errors, [
+                {
+                  code: 'INVALID_RESPONSE_BODY',
+                  errors: [
+                    {
+                      code: 'WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE',
+                      message: 'Write-only property `"": "writeonly"`, is not allowed in the response.',
+                      params: ["", "writeonly"],
+                      path: ["writeOnly"]
+                    }
+                  ],
+                  message: 'Invalid body: Write-only property `"": "writeonly"`, is not allowed in the response.',
+                  path: []
+                }
+              ]);
+              assert.equal(results.warnings.length, 0);
+            })
+            .then(done, done);
+        });
+
+        it('Test if response has CREATE only property marked with x-ms-mutability', function (done) {
+          var cSwaggerDoc = _.cloneDeep(helpers.swaggerDoc);
+
+          Sway.create({
+            definition: cSwaggerDoc
+          })
+            .then(function (api) {
+              var results = api.getOperation('/pet/{petId}', 'get').validateResponse({
+                body: createOnlyPet,
+                encoding: 'utf-8',
+                headers: {
+                  'content-type': 'application/json'
+                },
+                statusCode: 200
+              });
+
+              assert.deepEqual(results.errors, [
+                {
+                  code: 'INVALID_RESPONSE_BODY',
+                  errors: [
+                    {
+                      code: 'WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE',
+                      message: 'Write-only property `"": "createonly"`, is not allowed in the response.',
+                      params: ["", "createonly"],
+                      path: ["createOnly"]
+                    }
+                  ],
+                  message: 'Invalid body: Write-only property `"": "createonly"`, is not allowed in the response.',
+                  path: []
+                }
+              ]);
+              assert.equal(results.warnings.length, 0);
+            })
+            .then(done, done);
+        });
+
+        it('Test if response has UPDATE only property marked with x-ms-mutability', function (done) {
+          var cSwaggerDoc = _.cloneDeep(helpers.swaggerDoc);
+
+          Sway.create({
+            definition: cSwaggerDoc
+          })
+            .then(function (api) {
+              var results = api.getOperation('/pet/{petId}', 'get').validateResponse({
+                body: updateOnlyPet,
+                encoding: 'utf-8',
+                headers: {
+                  'content-type': 'application/json'
+                },
+                statusCode: 200
+              });
+
+              assert.deepEqual(results.errors, [
+                {
+                  code: 'INVALID_RESPONSE_BODY',
+                  errors: [
+                    {
+                      code: 'WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE',
+                      message: 'Write-only property `"": "updateonly"`, is not allowed in the response.',
+                      params: ["", "updateonly"],
+                      path: ["updateOnly"]
+                    }
+                  ],
+                  message: 'Invalid body: Write-only property `"": "updateonly"`, is not allowed in the response.',
                   path: []
                 }
               ]);

--- a/test/test-response.js
+++ b/test/test-response.js
@@ -672,8 +672,8 @@ describe('Response', function () {
                     {
                       code: 'SECRET_PROPERTY',
                       message: 'Secret property `"": "password"`, cannot be sent in the response.',
-                      params: ["", "password"],
-                      path: ["secret"]
+                      params: ['', 'password'],
+                      path: ['secret']
                     }
                   ],
                   message: 'Invalid body: Secret property `"": "password"`, cannot be sent in the response.',
@@ -708,8 +708,8 @@ describe('Response', function () {
                     {
                       code: 'WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE',
                       message: 'Write-only property `"": "writeonly"`, is not allowed in the response.',
-                      params: ["", "writeonly"],
-                      path: ["writeOnly"]
+                      params: ['', 'writeonly'],
+                      path: ['writeOnly']
                     }
                   ],
                   message: 'Invalid body: Write-only property `"": "writeonly"`, is not allowed in the response.',
@@ -744,8 +744,8 @@ describe('Response', function () {
                     {
                       code: 'WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE',
                       message: 'Write-only property `"": "createonly"`, is not allowed in the response.',
-                      params: ["", "createonly"],
-                      path: ["createOnly"]
+                      params: ['', 'createonly'],
+                      path: ['createOnly']
                     }
                   ],
                   message: 'Invalid body: Write-only property `"": "createonly"`, is not allowed in the response.',
@@ -780,8 +780,8 @@ describe('Response', function () {
                     {
                       code: 'WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE',
                       message: 'Write-only property `"": "updateonly"`, is not allowed in the response.',
-                      params: ["", "updateonly"],
-                      path: ["updateOnly"]
+                      params: ['', 'updateonly'],
+                      path: ['updateOnly']
                     }
                   ],
                   message: 'Invalid body: Write-only property `"": "updateonly"`, is not allowed in the response.',


### PR DESCRIPTION
Why do we need to Implement this User Story?
We need to implement this because we need this rule to check the response when discussing the RpSaaS team

To confirm the behavior for Live Validation,  we will check "x-ms-mutability": ["create", "update"] in the response and if we found a violation, we will report the error of ‘WRITEONLY_PROPERTY_NOT_ALLOWED_IN_RESPONSE’

