### PR TITLE
Update x-ms-secret validation logic for live validation

### DIFF
--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -216,8 +216,9 @@ function checkSecretPropertyInResponse (validateOptions, schema, json, report) {
 
   var isResponse = validateOptions && validateOptions.isResponse
   var xMsSecret = schema && schema['x-ms-secret']
+  var isXmsSecretTrue = Array.isArray(xMsSecret) && xMsSecret.length == 1 && xMsSecret[0] && typeof xMsSecret[0] === 'string' && xMsSecret[0].toLowerCase() === 'true'
 
-  if (isResponse && schema && xMsSecret && json !== undefined) {
+  if (isResponse && schema && xMsSecret && isXmsSecretTrue && json !== undefined) {
     let errorMessage = 'Secret property `"{0}": ';
 
     if (schema && schema.type === 'string' && typeof json === 'string') {

--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -218,7 +218,7 @@ function checkSecretPropertyInResponse (validateOptions, schema, json, report) {
   var xMsSecret = schema && schema['x-ms-secret']
   var isXmsSecretTrue = xMsSecret && typeof xMsSecret === 'string' && xMsSecret.toLowerCase() === 'true'
 
-  if (isResponse && schema && xMsSecret && isXmsSecretTrue && json !== undefined) {
+  if (isResponse && schema && isXmsSecretTrue && json !== undefined) {
     let errorMessage = 'Secret property `"{0}": ';
 
     if (schema && schema.type === 'string' && typeof json === 'string') {

--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -216,7 +216,7 @@ function checkSecretPropertyInResponse (validateOptions, schema, json, report) {
 
   var isResponse = validateOptions && validateOptions.isResponse
   var xMsSecret = schema && schema['x-ms-secret']
-  var isXmsSecretTrue = Array.isArray(xMsSecret) && xMsSecret.length == 1 && xMsSecret[0] && typeof xMsSecret[0] === 'string' && xMsSecret[0].toLowerCase() === 'true'
+  var isXmsSecretTrue = xMsSecret && typeof xMsSecret === 'string' && xMsSecret.toLowerCase() === 'true'
 
   if (isResponse && schema && xMsSecret && isXmsSecretTrue && json !== undefined) {
     let errorMessage = 'Secret property `"{0}": ';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yasway",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "A library that simplifies Swagger integrations.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/browser/documents/2.0/swagger.yaml
+++ b/test/browser/documents/2.0/swagger.yaml
@@ -682,10 +682,10 @@ definitions:
         - "sold"
       secret:
         type: "string"
-        x-ms-secret: ["true"]
+        x-ms-secret: "true"
       nonSecret:
         type: "string"
-        x-ms-secret: ["false"]
+        x-ms-secret: "false"
       writeOnly:
         type: "string"
         x-ms-mutability: ["create", "update"]

--- a/test/browser/documents/2.0/swagger.yaml
+++ b/test/browser/documents/2.0/swagger.yaml
@@ -682,7 +682,10 @@ definitions:
         - "sold"
       secret:
         type: "string"
-        x-ms-secret: ["secret"]
+        x-ms-secret: ["true"]
+      nonSecret:
+        type: "string"
+        x-ms-secret: ["false"]
       writeOnly:
         type: "string"
         x-ms-mutability: ["create", "update"]

--- a/test/test-response.js
+++ b/test/test-response.js
@@ -153,6 +153,12 @@ describe('Response', function () {
       secret: 'password'
     }
 
+    var nonSecretPet = {
+      name: 'Test Pet',
+      photoUrls: [],
+      nonSecret: 'notAnySecret'
+    }
+
     describe('validate Content-Type', function () {
       describe('operation level produces', function () {
         var cSway;
@@ -649,7 +655,7 @@ describe('Response', function () {
             .then(done, done);
         });
 
-        it('Test if response has secret property marked with x-ms-secret', function (done) {
+        it('Test if response has secret property marked with x-ms-secret that equals to TRUE', function (done) {
           var cSwaggerDoc = _.cloneDeep(helpers.swaggerDoc);
 
           Sway.create({
@@ -684,6 +690,30 @@ describe('Response', function () {
             })
             .then(done, done);
         });
+
+        it('Test if response has secret property marked with x-ms-secret that equals to FALSE', function (done) {
+          var cSwaggerDoc = _.cloneDeep(helpers.swaggerDoc);
+
+          Sway.create({
+            definition: cSwaggerDoc
+          })
+            .then(function (api) {
+              var results = api.getOperation('/pet/{petId}', 'get').validateResponse({
+                body: nonSecretPet,
+                encoding: 'utf-8',
+                headers: {
+                  'content-type': 'application/json'
+                },
+                statusCode: 200
+              });
+
+              // should not return any errors
+              assert.deepEqual(results.errors, []);
+              assert.equal(results.warnings.length, 0);
+            })
+            .then(done, done);
+        });
+
 
         it('Test if response has WRITE only property marked with x-ms-mutability', function (done) {
           var cSwaggerDoc = _.cloneDeep(helpers.swaggerDoc);


### PR DESCRIPTION
Per email discussion, x-ms-secret validation logic for live validation needs to be updated as the following:

"format" can take additional values and use x-ms-secret to express the intent. 
"adminPassword": {
    "type": "string",
    "format": "["password", "certificate"]",
    "x-ms-secret": "true"
  }
 
