### PR TITLE
Fix a perf issue caused by cloning schemaObj

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -25,7 +25,6 @@
 'use strict';
 
 var _ = require('lodash');
-var cloneDeep = require('clone-deep');
 var formatGenerators = require('./validation/format-generators');
 var formatValidators = require('./validation/format-validators');
 var customValidators = require('./validation/custom-zschema-validators');
@@ -471,10 +470,6 @@ module.exports.removeCirculars = function (obj) {
  * @returns {object} Object containing the errors and warnings of the validation
  */
 module.exports.validateAgainstSchema = function (validator, schema, value, schemaPath, isResponse, options) {
-  // Clone the schema as z-schema alters the provided document (https://github.com/zaggino/z-schema/issues/160#issuecomment-214901835). 
-  // Original lodash's deep clone was used but during memory profiling we've found lodash's deep clone takes a lot of CPU, according to this benchmark (https://github.com/ahmadnassri/benchmark-node-clone) and load testing, we've decided to replace lodash with this deep-clone library
-  schema = cloneDeep(schema); 
-
   var response = {
     errors: [],
     warnings: []


### PR DESCRIPTION
This PR tries to fix a perf problem caused by cloning `schemaObj`.

ZSchema has an internal [cache](https://github.com/zaggino/z-schema/blob/5b6a6e30a1f86026951b072b5639f7266c16ff78/src/SchemaCache.js#L124) inside [validate](https://github.com/zaggino/z-schema/blob/5b6a6e30a1f86026951b072b5639f7266c16ff78/src/ZSchema.js#L212) method, each time a different instance of `schemaObj` is encountered, it'll be pinned in memory and this will eventually exhaust system memory.

By calling `validate` using the same `schemaObj` instance, the same `schemaObj` instance is reused for each API request, and it eliminate the need to [compile](https://github.com/zaggino/z-schema/blob/5b6a6e30a1f86026951b072b5639f7266c16ff78/src/ZSchema.js#L217) and [validate](https://github.com/zaggino/z-schema/blob/5b6a6e30a1f86026951b072b5639f7266c16ff78/src/ZSchema.js#L226) `schemaObj` itself, giving us additional perf gain around RPS.

I looked though the [JsonValidation.validate](https://github.com/zaggino/z-schema/blob/5b6a6e30a1f86026951b072b5639f7266c16ff78/src/ZSchema.js#L242) method and it doesn't appear to mutate the input `schema` instance, so I assume it is safe to remove the `cloneDeep` method as well. But this needs extensive testing .