### PR TITLE
Ignore required check in response when it's secret.

### DIFF
--- a/lib/validation/custom-zschema-validators.js
+++ b/lib/validation/custom-zschema-validators.js
@@ -53,17 +53,21 @@ function requiredPropertyValidator (report, schema, json) {
   var idx = schema.required.length;
   var requiredPropertyName;
   var xMsMutability;
+  var xmsSecretValue;
+  var isTrueXmsSecret;
 
   while (idx--) {
     requiredPropertyName = schema.required[idx];
     xMsMutability = (schema.properties && schema.properties[`${requiredPropertyName}`]) && schema.properties[`${requiredPropertyName}`]['x-ms-mutability'];
+    xmsSecretValue = (schema.properties && schema.properties[`${requiredPropertyName}`]) && schema.properties[`${requiredPropertyName}`]['x-ms-secret'];
+    isTrueXmsSecret = xmsSecretValue && typeof xmsSecretValue === 'boolean' && xmsSecretValue === true;
 
     // If a response has x-ms-mutability property and its missing the read we can skip this step
     if (
       this.validateOptions &&
       this.validateOptions.isResponse &&
-      (xMsMutability &&
-        xMsMutability.indexOf('read') === -1) 
+      ((xMsMutability &&
+        xMsMutability.indexOf('read') === -1)) || (isTrueXmsSecret)
     ) {
       schema.properties[`${requiredPropertyName}`].isRequired = true;
       continue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yasway",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "A library that simplifies Swagger integrations.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/browser/documents/2.0/swagger.yaml
+++ b/test/browser/documents/2.0/swagger.yaml
@@ -830,6 +830,7 @@ definitions:
     required:
       - "name"
       - "photoUrls"
+      - "requiredSecret"
     properties:
       id:
         type: "integer"
@@ -866,6 +867,9 @@ definitions:
       nonSecret:
         type: "string"
         x-ms-secret: false
+      requiredSecret:
+        type: "string"
+        x-ms-secret: true
       writeOnly:
         type: "string"
         x-ms-mutability: ["create", "update"]

--- a/test/test-response.js
+++ b/test/test-response.js
@@ -165,6 +165,11 @@ describe('Response', function () {
       nonSecret: 'notAnySecret'
     }
 
+    var requiredSecretPet = {
+      name: 'Test Pet',
+      photoUrls: []
+    }
+
     describe('validate Content-Type', function () {
       describe('operation level produces', function () {
         var cSway;
@@ -740,6 +745,28 @@ describe('Response', function () {
                   path: []
                 }
               ]);
+              assert.equal(results.warnings.length, 0);
+            })
+            .then(done, done);
+        });
+
+        it('Test if response has secret property marked with x-ms-secret that equals to TRUE and also it is required property', function (done) {
+          var cSwaggerDoc = _.cloneDeep(helpers.swaggerDoc);
+
+          Sway.create({
+            definition: cSwaggerDoc
+          })
+            .then(function (api) {
+              var results = api.getOperation('/pet/{petId}', 'get').validateResponse({
+                body: requiredSecretPet,
+                encoding: 'utf-8',
+                headers: {
+                  'content-type': 'application/json'
+                },
+                statusCode: 200
+              });
+
+              assert.equal(results.errors.length, 0);
               assert.equal(results.warnings.length, 0);
             })
             .then(done, done);


### PR DESCRIPTION
When a property is annotated by both x-ms-secret: true and required, we will ignore the required check in response.